### PR TITLE
Fix the undefined index 'id' in case of error

### DIFF
--- a/Controller/JsonRpcController.php
+++ b/Controller/JsonRpcController.php
@@ -72,15 +72,16 @@ class JsonRpcController extends ContainerAware
     {
         $json = $httprequest->getContent();
         $request = json_decode($json, true);
+        $requestId = (isset($request['id']) ? $request['id'] : null);
 
         if ($request === null) {
             return $this->getErrorResponse(self::PARSE_ERROR, null);
         } elseif (!(isset($request['jsonrpc']) && isset($request['method']) && $request['jsonrpc'] == '2.0')) {
-            return $this->getErrorResponse(self::INVALID_REQUEST, $request['id']);
+            return $this->getErrorResponse(self::INVALID_REQUEST, $requestId);
         }
 
         if (!in_array($request['method'], array_keys($this->config['functions']))) {
-            return $this->getErrorResponse(self::METHOD_NOT_FOUND, $request['id']);
+            return $this->getErrorResponse(self::METHOD_NOT_FOUND, $requestId);
         }
 
         $service = $this->container->get($this->config['functions'][$request['method']]['service']);
@@ -94,7 +95,7 @@ class JsonRpcController extends ContainerAware
                 if (!(count($params) >= $r->getNumberOfRequiredParameters()
                     && count($params) <= $r->getNumberOfParameters())
                 ) {
-                    return $this->getErrorResponse(self::INVALID_PARAMS, $request['id'],
+                    return $this->getErrorResponse(self::INVALID_PARAMS, $requestId,
                         sprintf('Number of given parameters (%d) does not match the number of expected parameters (%d required, %d total)',
                             count($params), $r->getNumberOfRequiredParameters(), $r->getNumberOfParameters()));
                 }
@@ -105,7 +106,7 @@ class JsonRpcController extends ContainerAware
                     /* @var \ReflectionParameter $rp */
                     $name = $rp->name;
                     if (!isset($params->$name) && !$rp->isOptional()) {
-                        return $this->getErrorResponse(self::INVALID_PARAMS, $request['id'],
+                        return $this->getErrorResponse(self::INVALID_PARAMS, $requestId,
                             sprintf('Parameter %s is missing', $name));
                     }
                     if (isset($params->$name)) {
@@ -120,12 +121,12 @@ class JsonRpcController extends ContainerAware
             try {
                 $result = call_user_func_array(array($service, $method), $params);
             } catch (\Exception $e) {
-                return $this->getErrorResponse(self::INTERNAL_ERROR, $request['id'], $e->getMessage());
+                return $this->getErrorResponse(self::INTERNAL_ERROR, $requestId, $e->getMessage());
             }
 
             $response = array('jsonrpc' => '2.0');
             $response['result'] = $result;
-            $response['id'] = (isset($request['id']) ? $request['id'] : null);
+            $response['id'] = $requestId;
 
             if ($this->container->has('jms_serializer')) {
                 $response = $this->container->get('jms_serializer')->serialize($response, 'json', $this->serializationContext);
@@ -135,7 +136,7 @@ class JsonRpcController extends ContainerAware
 
             return new Response($response, 200, array('Content-Type' => 'application/json'));
         } else {
-            return $this->getErrorResponse(self::METHOD_NOT_FOUND, $request['id']);
+            return $this->getErrorResponse(self::METHOD_NOT_FOUND, $requestId);
         }
     }
 


### PR DESCRIPTION
In every case of error, the code use request['id']. But, the id is optional and aren't checked before. This will trigger the  warning "undefined index". Fix it.
