### PR TITLE
Ability to overwrite the exception to error data conversion

### DIFF
--- a/Controller/JsonRpcController.php
+++ b/Controller/JsonRpcController.php
@@ -164,7 +164,7 @@ class JsonRpcController extends ContainerAware
             try {
                 $result = call_user_func_array(array($service, $method), $params);
             } catch (\Exception $e) {
-                return $this->getErrorResponse(self::INTERNAL_ERROR, $requestId, $e->getMessage());
+                return $this->getErrorResponse(self::INTERNAL_ERROR, $requestId, $this->convertExceptionToErrorData($e));
             }
 
             $response = array('jsonrpc' => '2.0');
@@ -230,6 +230,11 @@ class JsonRpcController extends ContainerAware
         if (isset($this->functions[$alias])) {
             unset($this->functions[$alias]);
         }
+    }
+
+    protected function convertExceptionToErrorData(\Exception $e)
+    {
+        return $e->getMessage();
     }
 
     protected function getError($code)


### PR DESCRIPTION
The jsonrpc specification allows a structured value for its error object data member. I use this data to describe the caught exception in debug mode for the client. To do this I need to overwrite the controller and provide my own 'convertExceptionToErrorData' logic.