### PR TITLE
Made the route trailing slash optional

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,3 +1,4 @@
 wa72_json_rpc:
-    pattern: /
-    defaults: { _controller: wa72_jsonrpc.jsonrpccontroller:execute }
+    pattern: "{optionalTrailingSlash}"
+    defaults: { _controller: wa72_jsonrpc.jsonrpccontroller:execute, optionalTrailingSlash : "/" }
+    requirements: { optionalTrailingSlash : "[/]{0,1}" }


### PR DESCRIPTION
The trailing slash for the given prefix is now optional.
Both /endpointPrefix and /endpointPrefix/ are now valid.