### PR TITLE
Keeping the default value if exists for the not passed arguments from the AJAX call

### DIFF
--- a/Controller/JsonRpcController.php
+++ b/Controller/JsonRpcController.php
@@ -147,7 +147,7 @@ class JsonRpcController implements ContainerAwareInterface
                     if (isset($params[$rp->name])) {
                         $newparams[] = $params[$rp->name];
                     } else {
-                        $newparams[] = null;
+                        $newparams[] = $rp->getDefaultValue();
                     }
                 }
                 $params = $newparams;

--- a/Controller/JsonRpcController.php
+++ b/Controller/JsonRpcController.php
@@ -147,7 +147,7 @@ class JsonRpcController implements ContainerAwareInterface
                     if (isset($params[$rp->name])) {
                         $newparams[] = $params[$rp->name];
                     } else {
-                        $newparams[] = $rp->getDefaultValue();
+                        $newparams[] = $rp->isOptional() ? $rp->getDefaultValue() : null;
                     }
                 }
                 $params = $newparams;


### PR DESCRIPTION
When the function has arguments with default values _**jsonrpc-bundle**_ returns null

```
class Car{
    public function color(bool $hexa = true){
        var_dump($hexa); // return null
    }
}
```

I changed it to return the default value by changing the `null` to `$rp->isOptional() ? $rp->getDefaultValue() : null;` in `Controller/JsonRpcController.php line 150 `
```
class Car{
    public function color(bool $hexa = true){
        var_dump($hexa); // return true 
    }
}
```